### PR TITLE
fix pattern breaks

### DIFF
--- a/ibxm-js/IBXM.js
+++ b/ibxm-js/IBXM.js
@@ -224,7 +224,8 @@ function IBXMReplay( module, samplingRate ) {
 					break;
 				case 0xD: case 0x83: /* Pattern Break.*/
 					if( plCount < 0 ) {
-						breakSeqPos = seqPos + 1;
+						if (breakSeqPos == -1)
+							breakSeqPos = seqPos + 1;
 						nextRow = ( note.param >> 4 ) * 10 + ( note.param & 0xF );
 					}
 					break;


### PR DESCRIPTION
If there's a Bxx and a Dxx on the same row, they work combined. See http://modarchive.org/index.php?request=view_by_moduleid&query=175253 for example.