### PR TITLE
read instrument number 

### DIFF
--- a/micromod-c/micromod.c
+++ b/micromod-c/micromod.c
@@ -380,7 +380,7 @@ static long sequence_row() {
 		note->key  = ( pattern_data[ pat_offset ] & 0xF ) << 8;
 		note->key |=   pattern_data[ pat_offset + 1 ];
 		note->instrument  = pattern_data[ pat_offset + 2 ] >> 4;
-		note->instrument |= pattern_data[ pat_offset ] & 0x10;
+		note->instrument |= pattern_data[ pat_offset ] & 0xF0;
 		effect = pattern_data[ pat_offset + 2 ] & 0xF;
 		param = pattern_data[ pat_offset + 3 ];
 		pat_offset += 4;


### PR DESCRIPTION
The first 4 Bits of the first byte of each note are the upper four bits of the instrument number, so i think this should be 0xF0 and not 0x10, shouldn't it?
