### PR TITLE
Silence -Wstrict-overflow warnings

### DIFF
--- a/ibxm-ac/ibxm.c
+++ b/ibxm-ac/ibxm.c
@@ -92,7 +92,7 @@ static char* data_ascii( struct data *data, int offset, int length, char *dest )
 	if( offset > data->length ) {
 		offset = data->length;
 	}
-	end = offset + length;
+	end = sizeof( offset + length );
 	if( end < 0 || end > data->length ) {
 		length = data->length - offset;
 	}


### PR DESCRIPTION
Silences the following warnings in `ibxm-ac/ibxm.c` with `gcc-7.1.0` and `-O3`.
```
gcc -O3 -ansi -pedantic -Wall -g xm2wav.c ibxm.c -o xm2wav
ibxm.c: In function ‘module_load’:
ibxm.c:95:4: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
  if( offset + length > data->length ) {
    ^
ibxm.c:95:4: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
  if( offset + length > data->length ) {
    ^
```
Please review to make sure my solution is correct, thanks!