### PR TITLE
Stop using global state in C version (and do some insignificant improvements)

### DIFF
--- a/micromod-c/micromod.h
+++ b/micromod-c/micromod.h
@@ -6,6 +6,18 @@
 #endif
 
 /*
+	Coders-friendly way to know API version in form ABB, where
+	same A and different BB mean insignificant API extentions
+	while keeping full compatiblity
+
+	API version history:
+	< 200 or not defined = global state API
+	2xx                  = OOP-like API, compatible with global state API
+*/
+
+#define MICROMOD_API_VERSION 200
+
+/*
 	Structures for internal usage
 */
 

--- a/micromod-c/micromod.h
+++ b/micromod-c/micromod.h
@@ -1,3 +1,56 @@
+#ifndef __MICROMOD_H
+#define __MICROMOD_H
+
+#ifndef MICROMOD_MAX_CHANNELS
+#define MICROMOD_MAX_CHANNELS 16
+#endif
+
+/*
+	Structures for internal usage
+*/
+
+struct micromod_note {
+	unsigned short key;
+	unsigned char instrument, effect, param;
+};
+
+struct micromod_instrument {
+	unsigned char volume, fine_tune;
+	unsigned long loop_start, loop_length;
+	signed char *sample_data;
+};
+
+/*
+	Main object-like structure
+*/
+
+struct micromod_channel {
+	struct micromod_note note;
+	unsigned short period, porta_period;
+	unsigned long sample_offset, sample_idx, step;
+	unsigned char volume, panning, fine_tune, ampl, mute;
+	unsigned char id, instrument, assigned, porta_speed, pl_row, fx_count;
+	unsigned char vibrato_type, vibrato_phase, vibrato_speed, vibrato_depth;
+	unsigned char tremolo_type, tremolo_phase, tremolo_speed, tremolo_depth;
+	signed char tremolo_add, vibrato_add, arpeggio_add;
+};
+
+struct micromod_obj {
+	signed char *module_data;
+	unsigned char *pattern_data, *sequence;
+	long song_length, restart, num_patterns, num_channels;
+	struct micromod_instrument instruments[ 32 ];
+
+	long sample_rate, gain, c2_rate, tick_len, tick_offset;
+	long pattern, break_pattern, row, next_row, tick;
+	long speed, pl_count, pl_channel, random_seed;
+
+	struct micromod_channel channels[ MICROMOD_MAX_CHANNELS ];
+};
+
+/*
+	Common functions
+*/
 
 /*
 	Returns a string containing version information.
@@ -11,11 +64,15 @@ const char *micromod_get_version( void );
 long micromod_calculate_mod_file_len( signed char *module_header );
 
 /*
+	Instance-specific functions
+*/
+
+/*
 	Set the player to play the specified module data.
 	Returns -1 if the data is not recognised as a module.
 	Returns -2 if the sampling rate is less than 8000hz.
 */
-long micromod_initialise( signed char *data, long sampling_rate );
+long micromod_initialise_obj( struct micromod_obj* obj, signed char *data, long sampling_rate );
 
 /*
 	Obtains song and instrument names from the module.
@@ -23,34 +80,47 @@ long micromod_initialise( signed char *data, long sampling_rate );
 	The name is copied into the location pointed to by string,
 	and is at most 23 characters long, including the trailing null.
 */
-void micromod_get_string( long instrument, char *string );
+void micromod_get_string_obj( struct micromod_obj* obj, long instrument, char *string );
 
 /*
 	Returns the total song duration in samples at the current sampling rate.
 */
-long micromod_calculate_song_duration( void );
+long micromod_calculate_song_duration_obj( struct micromod_obj* obj );
 
 /*
 	Jump directly to a specific pattern in the sequence.
 */
-void micromod_set_position( long pos );
+void micromod_set_position_obj( struct micromod_obj* obj, long pos );
 
 /*
 	Mute the specified channel.
 	If channel is negative, un-mute all channels.
 	Returns the number of channels.
 */
-long micromod_mute_channel( long channel );
+long micromod_mute_channel_obj( struct micromod_obj* obj, long channel );
 
 /*
 	Set the playback gain.
 	For 4-channel modules, a value of 64 can be used without distortion.
 	For 8-channel modules, a value of 32 or less is recommended.
 */
-void micromod_set_gain( long value );
+void micromod_set_gain_obj( struct micromod_obj* obj, long value );
 
 /*
 	Calculate the specified number of stereo samples of audio.
 	Output buffer must be zeroed.
 */
-void micromod_get_audio( short *output_buffer, long count );
+void micromod_get_audio_obj( struct micromod_obj* obj, short *output_buffer, long count );
+
+/*
+	Global instance versions (provided for compatiblity, shouldn't be used in new programs)
+*/
+
+__attribute__ ((deprecated)) long micromod_initialise( signed char *data, long sampling_rate );
+__attribute__ ((deprecated)) void micromod_get_string( long instrument, char *string );
+__attribute__ ((deprecated)) long micromod_calculate_song_duration( void );
+__attribute__ ((deprecated)) void micromod_set_position( long pos );
+__attribute__ ((deprecated)) long micromod_mute_channel( long channel );
+__attribute__ ((deprecated)) void micromod_set_gain( long value );
+__attribute__ ((deprecated)) void micromod_get_audio( short *output_buffer, long count );
+#endif

--- a/micromod-c/mod2wav.c
+++ b/micromod-c/mod2wav.c
@@ -31,6 +31,8 @@ static const short key_to_period[] = { 1814, /*
 static short mix_buf[ 8192 ];
 static int filt_l, filt_r, qerror, interrupted;
 
+struct micromod_obj mmodobj;
+
 static int read_file( char *file_name, void *buffer, int limit ) {
 	int file_length = -1, bytes_read;
 	FILE *input_file = fopen( file_name, "rb" );
@@ -209,7 +211,7 @@ static int get_audio_s16le( char *out_buf, int num_samples ) {
 			count = length - offset;
 		}
 		memset( mix_buf, 0, count * sizeof( short ) );
-		micromod_get_audio( mix_buf, count >> 1 );
+		micromod_get_audio_obj( &mmodobj, mix_buf, count >> 1 );
 		downsample( mix_buf, mix_buf, count >> 1 );
 		crossfeed( mix_buf, count >> 2 );
 		idx = 0;
@@ -231,7 +233,7 @@ static int get_audio_s8( char *out_buf, int length, int gain ) {
 			count = length - offset;
 		}
 		memset( mix_buf, 0, ( count << 2 ) * sizeof( short ) );
-		micromod_get_audio( mix_buf, count << 1 );
+		micromod_get_audio_obj( &mmodobj, mix_buf, count << 1 );
 		downsample( mix_buf, mix_buf, count << 1 );
 		quantize( mix_buf, &out_buf[ offset ], gain, count );
 		offset += count;
@@ -310,18 +312,18 @@ static int mod_to_wav( signed char *module_data, char *file_name, int sample_rat
 	} else {
 		printf( "Generating %d 8-bit mono %s files.\n", num_files, type == IFF ? "IFF-8SVX" : "RAW" );
 	}
-	result = micromod_initialise( module_data, sample_rate * 2 );
+	result = micromod_initialise_obj( &mmodobj, module_data, sample_rate * 2 );
 	if( result == 0 ) {
-		num_channels = micromod_mute_channel( -1 );
+		num_channels = micromod_mute_channel_obj( &mmodobj, -1 );
 		if( chan >= 0 && chan < num_channels ) {
 			printf( "Muting all but channel %d.\n", chan );
 			for( idx = 0; idx < num_channels; idx++ ) {
 				if( idx != chan ) {
-					micromod_mute_channel( idx );
+					micromod_mute_channel_obj( &mmodobj, idx );
 				}
 			}
 		}
-		duration = micromod_calculate_song_duration() >> 1;
+		duration = micromod_calculate_song_duration_obj( &mmodobj ) >> 1;
 		count = num_files > 0 ? duration / num_files : duration;
 		while( offset < duration && result == 0 && !interrupted ) {
 			if( file >= num_files - 1 ) {

--- a/micromod-c/mod2wav.c
+++ b/micromod-c/mod2wav.c
@@ -8,6 +8,10 @@
 
 #include "micromod.h"
 
+#if !MICROMOD_API_VERSION || MICROMOD_API_VERSION < 200
+#error "MICROMOD_API_VERSION 200 or higher is required"
+#endif
+
 /*
 	Protracker MOD to WAV/IFF-8SVX converter. (c)2018 mumart@gmail.com
 */

--- a/micromod-c/sdlplayer.c
+++ b/micromod-c/sdlplayer.c
@@ -8,6 +8,10 @@
 
 #include "micromod.h"
 
+#if !MICROMOD_API_VERSION || MICROMOD_API_VERSION < 200
+#error "MICROMOD_API_VERSION 200 or higher is required"
+#endif
+
 /*
 	Simple command-line test player for micromod using SDL.
 */

--- a/micromod-c/sdlplayer.c
+++ b/micromod-c/sdlplayer.c
@@ -24,6 +24,8 @@ static short reverb_buffer[ REVERB_BUF_LEN ];
 static short mix_buffer[ BUFFER_SAMPLES * NUM_CHANNELS * OVERSAMPLE ];
 static long reverb_len, reverb_idx, filt_l, filt_r;
 
+struct micromod_obj mmodobj;
+
 /*
 	2:1 downsampling with simple but effective anti-aliasing.
 	Count is the number of stereo samples to process, and must be even.
@@ -84,7 +86,7 @@ static void audio_callback( void *udata, Uint8 *stream, int len ) {
 	if( count > 0 ) {
 		/* Get audio from replay.*/
 		memset( mix_buffer, 0, count * NUM_CHANNELS * sizeof( short ) );
-		micromod_get_audio( mix_buffer, count );
+		micromod_get_audio_obj( &mmodobj, mix_buffer, count );
 		downsample( mix_buffer, ( short * ) stream, count );
 		crossfeed( ( short * ) stream, count / OVERSAMPLE );
 		reverb( ( short * ) stream, count / OVERSAMPLE );
@@ -123,9 +125,9 @@ static void print_module_info() {
 	int inst;
 	char string[ 23 ];
 	for( inst = 0; inst < 16; inst++ ) {
-		micromod_get_string( inst, string );
+		micromod_get_string_obj( &mmodobj, inst, string );
 		printf( "%02i - %-22s ", inst, string );
-		micromod_get_string( inst + 16, string );
+		micromod_get_string_obj( &mmodobj, inst + 16, string );
 		printf( "%02i - %-22s\n", inst + 16, string );
 	}
 }
@@ -150,11 +152,11 @@ static long play_module( signed char *module ) {
 	long result;
 	SDL_AudioSpec audiospec;
 	/* Initialise replay.*/
-	result = micromod_initialise( module, SAMPLING_FREQ * OVERSAMPLE );
+	result = micromod_initialise_obj( &mmodobj, module, SAMPLING_FREQ * OVERSAMPLE );
 	if( result == 0 ) {
 		print_module_info();
 		/* Calculate song length. */
-		samples_remaining = micromod_calculate_song_duration();
+		samples_remaining = micromod_calculate_song_duration_obj( &mmodobj );
 		printf( "Song Duration: %li seconds.\n", samples_remaining / ( SAMPLING_FREQ * OVERSAMPLE ) );
 		fflush( NULL );
 		/* Initialise SDL_AudioSpec Structure. */


### PR DESCRIPTION
I've already explained reasons behind this in #15. This PR does the following:

* Moves all `static` non-const vars into `struct micromod_obj`
* Replaces functions which were using them with their `_obj` versions which accept pointer to struct as first argument
* Structs are now parts of header so they are renamed with prefix `micromod_`
* Adds include guard
* Adds macro for API version
* Ports `mod2wav` and `sdlplayer` to new API
* Minor changes to code which doesn't affect anything

It is compatible with old version. To keep it this way there's global instance of `struct micromod_obj` and wrappers around new functions which use it. Old functions are marked with `__attribute__ ((deprecated))` but are working.

What this PR **doesn't** do:

* Updates `w2player` to new API becuase I'm on linux and can't test it anyways
* Changes `MICROMOD_VERSION` because I'm unsure what is correct new value